### PR TITLE
Add regex match for "Bearer"

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 module.exports = (req, res, next) => {
     const [left, right] = req.headers.authorization ? req.headers.authorization.split(' ') : [];
-    if(left === 'Bearer') {
+    if(left.match(/bearer/i)) {
         req.accessToken = right;
         return next();
     }


### PR DESCRIPTION
Ran into issue where user was cURLing my endpoint with "bearer" in front of access token. Adding regex match resolved this for me locally.